### PR TITLE
Make library source files compilable on GNU/Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ artifacts/
 *_i.h
 *.ilk
 *.meta
+*.o
 *.obj
 *.pch
 *.pdb

--- a/BorisEngine2/BorisConsoleManager.cpp
+++ b/BorisEngine2/BorisConsoleManager.cpp
@@ -14,7 +14,7 @@ BorisConsoleManager* BorisConsoleManager::Instance()
 
 void BorisConsoleManager::Print(String text)
 {
-	Print((char*)BorisOperations::String_to_LPCSTR(text));
+	Print((char*)BorisOperations::String_to_Str(text));
 }
 
 void BorisConsoleManager::Print(char* text)

--- a/BorisEngine2/BorisOperations.cpp
+++ b/BorisEngine2/BorisOperations.cpp
@@ -64,9 +64,8 @@ namespace BorisOperations
 
 	bool FileExists(const String& filename)
 	{
-		std::filesystem::path path_obj(filename);
-		std::filesystem::directory_entry file(path_obj);
-		return std::filesystem::exists(file);
+		struct stat buf;
+		return stat(filename.c_str(), &buf) != -1;
 	}
 
 	float GetDistance(Vector2 a, Vector2 b)

--- a/BorisEngine2/BorisOperations.cpp
+++ b/BorisEngine2/BorisOperations.cpp
@@ -192,8 +192,8 @@ namespace BorisOperations
 	bool LineIntersectsCircle(Vector2 lineStartPosition, Vector2 lineDirection, Circle circle)
 	{
 		/* first, check if the lineStartPosition point is inside the circle! */
-		float delX = (circle.X - lineStartPosition.X);
-		float delY = (circle.Y - lineStartPosition.Y);
+		float delX = (circle.centre.X - lineStartPosition.X);
+		float delY = (circle.centre.Y - lineStartPosition.Y);
 		float quadrance = (delX*delX) + (delY*delY);
 		if (quadrance <= circle.radius*circle.radius) {
 			return true;
@@ -213,8 +213,8 @@ namespace BorisOperations
 			}
 
 			/* now for the hard part: we want to check if the ray actually intersects a circle */
-			return (lineStartPosition.X >= (circle.centre.X - radius)) &&
-						 (lineStartPosition.X <= (circle.centre.X + radius));
+			return (lineStartPosition.X >= (circle.centre.X - circle.radius)) &&
+						 (lineStartPosition.X <= (circle.centre.X + circle.radius));
 		} else if (lineDirection.Y == 0) {
 			/* check if the circle's center is in the opposite direction of the ray. */
 			if (lineDirection.X > 0) {
@@ -230,14 +230,14 @@ namespace BorisOperations
 			}
 
 			/* now for the hard part: we want to check if the ray actually intersects a circle */
-			return (lineStartPosition.Y >= (circle.centre.Y - radius)) &&
-						 (lineStartPosition.Y <= (circle.centre.Y + radius));
+			return (lineStartPosition.Y >= (circle.centre.Y - circle.radius)) &&
+						 (lineStartPosition.Y <= (circle.centre.Y + circle.radius));
 		} else {
 			float slope = ((float)lineDirection.Y) / lineDirection.X;
 			float orthogonalSlope = ((float) (0 - lineDirection.X) / lineDirection.Y);
 			/* check if the circle's center is in the opposite direction of the ray. */
 			if (orthogonalSlope > 0) {
-				float threshold = (orthogonalSlope*circle.centre.X) - (m*lineStartPosition.X) + lineStartPosition.Y;
+				float threshold = (orthogonalSlope*circle.centre.X) - (slope*lineStartPosition.X) + lineStartPosition.Y;
 				if (lineDirection.X > 0) {
 					/* the ray is pointed down and to the right (fourth quadrant) */
 					if (circle.centre.Y > threshold) {
@@ -245,12 +245,12 @@ namespace BorisOperations
 					}
 				} else {
 					/* the ray is pointed up and to the left (second quadrant) */
-					if (circle.centre.y < threshold) {
+					if (circle.centre.Y < threshold) {
 						return false;
 					}
 				}
 			} else {
-				float threshold = (orthogonalSlope*circle.centre.X) - (m*lineStartPosition.X) + lineStartPosition.Y;
+				float threshold = (orthogonalSlope*circle.centre.X) - (slope*lineStartPosition.X) + lineStartPosition.Y;
 				if (lineDirection.X > 0) {
 					/* the ray is pointed up and to the right (first quadrant) */
 					if (circle.centre.Y < threshold) {
@@ -258,7 +258,7 @@ namespace BorisOperations
 					}
 				} else {
 					/* the ray is pointed down and to the left (third quadrant) */
-					if (circle.centre.y > threshold) {
+					if (circle.centre.Y > threshold) {
 						return false;
 					}
 				}
@@ -266,7 +266,7 @@ namespace BorisOperations
 			
 			/* now for the hard part: we want to check if the ray actually intersects a circle */
 			float a = slope*slope + 1;
-			float b = 2*slope*(slope*lineStartPosition.X + lineStartPosition.Y - circle.centre.Y) - (2*circle.centre.x);
+			float b = 2*slope*(slope*lineStartPosition.X + lineStartPosition.Y - circle.centre.Y) - (2*circle.centre.X);
 			float c = (slope*slope*lineStartPosition.X*lineStartPosition.X) + (lineStartPosition.Y*lineStartPosition.Y) + (circle.centre.Y*circle.centre.Y);
 			c -= 2*slope*lineStartPosition.X*lineStartPosition.Y;
 			c += 2*slope*lineStartPosition.X*circle.centre.Y;

--- a/BorisEngine2/BorisOperations.cpp
+++ b/BorisEngine2/BorisOperations.cpp
@@ -7,7 +7,8 @@ namespace BorisOperations
 		return b ? "true" : "false";
 	}
 
-	LPCSTR Char_to_LPCSTR(char c)
+	/* FIXME memory leak here... T.T */
+	const char *Char_to_Str(char c)
 	{
 		return new char[2] {c, '\0'};
 	}
@@ -25,12 +26,16 @@ namespace BorisOperations
 			return false;
 		}
 		String dir = dirParts[0];
-		for (int i = 1; i < dirParts.size(); i++)
+		for (size_t i = 1; i < dirParts.size(); i++)
 		{
 			dir += "\\" + dirParts[i];
 			if (!FileExists(dir))
 			{
-				if (!CreateDirectory(String_to_LPCSTR(dir), NULL))
+#ifdef _MSC_VER
+				if (!CreateDirectory(String_to_Str(dir), NULL))
+#else
+				if (!std::filesystem::create_directory(String_to_Str(dir)))
+#endif
 				{
 					return false;
 				}
@@ -59,8 +64,9 @@ namespace BorisOperations
 
 	bool FileExists(const String& filename)
 	{
-		struct stat buf;
-		return stat(filename.c_str(), &buf) != -1;
+		std::filesystem::path path_obj(filename);
+		std::filesystem::directory_entry file(path_obj);
+		return std::filesystem::exists(file);
 	}
 
 	float GetDistance(Vector2 a, Vector2 b)
@@ -85,10 +91,10 @@ namespace BorisOperations
 		return{ Round(frect.X),Round(frect.Y),Round(frect.W),Round(frect.H) };
 	}
 
-	LPCSTR Int_to_LPCSTR(int num)
+	const char *Int_to_Str(int num)
 	{
 		//TODO: Optimize this.
-		return String_to_LPCSTR(std::to_string(num));
+		return String_to_Str(std::to_string(num));
 	}
 
 	float Lerp(float a, float b, float f)
@@ -157,11 +163,11 @@ namespace BorisOperations
 		return result;
 	}
 
-	LPCSTR String_to_LPCSTR(String str)
+	const char *String_to_Str(String str)
 	{
 		std::ostringstream ss;
 		ss << str;
-		return _strdup(ss.str().c_str());
+		return strdup(ss.str().c_str());
 	}
 
 	SDL_Point Vector2ToSDLPoint(Vector2 vec2)
@@ -184,6 +190,7 @@ namespace BorisOperations
 		}
 	}
 
+	/* FIXME unimplemented! */
 	bool LineIntersectsCircle(Vector2 lineStartPosition, Vector2 lineDirection, Circle circle)
 	{
 		return false;

--- a/BorisEngine2/BorisOperations.cpp
+++ b/BorisEngine2/BorisOperations.cpp
@@ -230,10 +230,14 @@ namespace BorisOperations
 		}
 		
 		/* now for the hard part: we want to check if the ray actually intersects a circle */
-		/* FIXME unimplemented! */
-		// TODO implement this step
-		
-		return false;
+		float a = slope*slope + 1;
+		float b = 2*slope*(slope*lineStartPosition.X + lineStartPosition.Y - circle.centre.Y) - (2*circle.centre.x);
+		float c = (slope*slope*lineStartPosition.X*lineStartPosition.X) + (lineStartPosition.Y*lineStartPosition.Y) + (circle.centre.Y*circle.centre.Y);
+		c -= 2*slope*lineStartPosition.X*lineStartPosition.Y;
+		c += 2*slope*lineStartPosition.X*circle.centre.Y;
+		c -= 2*lineStartPosition.Y*circle.centre.Y;
+		float discriminant = b*b - (4*a*c);
+		return discriminant >= 0;
 	}
 }
 

--- a/BorisEngine2/BorisOperations.cpp
+++ b/BorisEngine2/BorisOperations.cpp
@@ -189,9 +189,51 @@ namespace BorisOperations
 		}
 	}
 
-	/* FIXME unimplemented! */
 	bool LineIntersectsCircle(Vector2 lineStartPosition, Vector2 lineDirection, Circle circle)
 	{
+		/* first, check if the lineStartPosition point is inside the circle! */
+		float delX = (circle.X - lineStartPosition.X);
+		float delY = (circle.Y - lineStartPosition.Y);
+		float quadrance = (delX*delX) + (delY*delY);
+		if (quadrance < circle.radius*circle*radius) {
+			return true;
+		}
+		float slope = ((float)lineDirection.Y) / lineDirection.X;
+		float orthogonalSlope = ((float) (0 - lineDirection.X) / lineDirection.Y);
+		/* check if the circle's center is in the opposite direction of the ray. */
+		if (orthogonalSlope > 0) {
+			float threshold = (orthogonalSlope*circle.centre.X) - (m*lineStartPosition.X) + lineStartPosition.Y;
+			if (lineDirection.X > 0) {
+				/* the ray is pointed down and to the right (fourth quadrant) */
+				if (circle.centre.Y > threshold) {
+					return false;
+				}
+			} else {
+				/* the ray is pointed up and to the left (second quadrant) */
+				if (circle.centre.y < threshold) {
+					return false;
+				}
+			}
+		} else {
+			float threshold = (orthogonalSlope*circle.centre.X) - (m*lineStartPosition.X) + lineStartPosition.Y;
+			if (lineDirection.X > 0) {
+				/* the ray is pointed up and to the right (first quadrant) */
+				if (circle.centre.Y < threshold) {
+					return false;
+				}
+			} else {
+				/* the ray is pointed down and to the left (third quadrant) */
+				if (circle.centre.y > threshold) {
+					return false;
+				}
+			}
+		}
+		
+		/* now for the hard part: we want to check if the ray actually intersects a circle */
+		/* FIXME unimplemented! */
+		// TODO implement this step
+		
 		return false;
 	}
 }
+

--- a/BorisEngine2/BorisOperations.cpp
+++ b/BorisEngine2/BorisOperations.cpp
@@ -195,49 +195,85 @@ namespace BorisOperations
 		float delX = (circle.X - lineStartPosition.X);
 		float delY = (circle.Y - lineStartPosition.Y);
 		float quadrance = (delX*delX) + (delY*delY);
-		if (quadrance < circle.radius*circle*radius) {
+		if (quadrance <= circle.radius*circle.radius) {
 			return true;
 		}
-		float slope = ((float)lineDirection.Y) / lineDirection.X;
-		float orthogonalSlope = ((float) (0 - lineDirection.X) / lineDirection.Y);
-		/* check if the circle's center is in the opposite direction of the ray. */
-		if (orthogonalSlope > 0) {
-			float threshold = (orthogonalSlope*circle.centre.X) - (m*lineStartPosition.X) + lineStartPosition.Y;
-			if (lineDirection.X > 0) {
-				/* the ray is pointed down and to the right (fourth quadrant) */
-				if (circle.centre.Y > threshold) {
+		if (lineDirection.X == 0) {
+			/* check if the circle's center is in the opposite direction of the ray. */
+			if (lineDirection.Y > 0) {
+				if (circle.centre.Y < lineStartPosition.Y) {
+					return false;
+				}
+			} else if (lineDirection.Y < 0) {
+				if (circle.centre.Y > lineStartPosition.Y) {
 					return false;
 				}
 			} else {
-				/* the ray is pointed up and to the left (second quadrant) */
-				if (circle.centre.y < threshold) {
+				return false;
+			}
+
+			/* now for the hard part: we want to check if the ray actually intersects a circle */
+			return (lineStartPosition.X >= (circle.centre.X - radius)) &&
+						 (lineStartPosition.X <= (circle.centre.X + radius));
+		} else if (lineDirection.Y == 0) {
+			/* check if the circle's center is in the opposite direction of the ray. */
+			if (lineDirection.X > 0) {
+				if (circle.centre.X < lineStartPosition.X) {
 					return false;
 				}
+			} else if (lineDirection.X < 0) {
+				if (circle.centre.X > lineStartPosition.X) {
+					return false;
+				}
+			} else {
+				return false;
 			}
+
+			/* now for the hard part: we want to check if the ray actually intersects a circle */
+			return (lineStartPosition.Y >= (circle.centre.Y - radius)) &&
+						 (lineStartPosition.Y <= (circle.centre.Y + radius));
 		} else {
-			float threshold = (orthogonalSlope*circle.centre.X) - (m*lineStartPosition.X) + lineStartPosition.Y;
-			if (lineDirection.X > 0) {
-				/* the ray is pointed up and to the right (first quadrant) */
-				if (circle.centre.Y < threshold) {
-					return false;
+			float slope = ((float)lineDirection.Y) / lineDirection.X;
+			float orthogonalSlope = ((float) (0 - lineDirection.X) / lineDirection.Y);
+			/* check if the circle's center is in the opposite direction of the ray. */
+			if (orthogonalSlope > 0) {
+				float threshold = (orthogonalSlope*circle.centre.X) - (m*lineStartPosition.X) + lineStartPosition.Y;
+				if (lineDirection.X > 0) {
+					/* the ray is pointed down and to the right (fourth quadrant) */
+					if (circle.centre.Y > threshold) {
+						return false;
+					}
+				} else {
+					/* the ray is pointed up and to the left (second quadrant) */
+					if (circle.centre.y < threshold) {
+						return false;
+					}
 				}
 			} else {
-				/* the ray is pointed down and to the left (third quadrant) */
-				if (circle.centre.y > threshold) {
-					return false;
+				float threshold = (orthogonalSlope*circle.centre.X) - (m*lineStartPosition.X) + lineStartPosition.Y;
+				if (lineDirection.X > 0) {
+					/* the ray is pointed up and to the right (first quadrant) */
+					if (circle.centre.Y < threshold) {
+						return false;
+					}
+				} else {
+					/* the ray is pointed down and to the left (third quadrant) */
+					if (circle.centre.y > threshold) {
+						return false;
+					}
 				}
 			}
+			
+			/* now for the hard part: we want to check if the ray actually intersects a circle */
+			float a = slope*slope + 1;
+			float b = 2*slope*(slope*lineStartPosition.X + lineStartPosition.Y - circle.centre.Y) - (2*circle.centre.x);
+			float c = (slope*slope*lineStartPosition.X*lineStartPosition.X) + (lineStartPosition.Y*lineStartPosition.Y) + (circle.centre.Y*circle.centre.Y);
+			c -= 2*slope*lineStartPosition.X*lineStartPosition.Y;
+			c += 2*slope*lineStartPosition.X*circle.centre.Y;
+			c -= 2*lineStartPosition.Y*circle.centre.Y;
+			float discriminant = b*b - (4*a*c);
+			return discriminant >= 0;
 		}
-		
-		/* now for the hard part: we want to check if the ray actually intersects a circle */
-		float a = slope*slope + 1;
-		float b = 2*slope*(slope*lineStartPosition.X + lineStartPosition.Y - circle.centre.Y) - (2*circle.centre.x);
-		float c = (slope*slope*lineStartPosition.X*lineStartPosition.X) + (lineStartPosition.Y*lineStartPosition.Y) + (circle.centre.Y*circle.centre.Y);
-		c -= 2*slope*lineStartPosition.X*lineStartPosition.Y;
-		c += 2*slope*lineStartPosition.X*circle.centre.Y;
-		c -= 2*lineStartPosition.Y*circle.centre.Y;
-		float discriminant = b*b - (4*a*c);
-		return discriminant >= 0;
 	}
 }
 

--- a/BorisEngine2/BorisOperations.h
+++ b/BorisEngine2/BorisOperations.h
@@ -14,51 +14,71 @@
 //A namespace used to contain a bunch of miscellaneous subroutines.
 namespace BorisOperations
 {
+
 	//Return "true" if b is true and "false" if b is false.
 	String BoolToString(bool b);
+
 	//A method which returns an const char * value representing a character.
 	const char * Char_to_Str(char c);
+
 	//A method which returns a std::string representing a character.
 	String CharToString(char c);
+
 	//A method which creates a given directory if
 	//it doesn't already exist.
 	bool CreateFolder(String dirname);
+
 	SDL_Surface* CreateSurface(unsigned int bytesPerPixel, void *pixels, int width, int height, int depth, int pitch);
+
 	//A method which returns a boolean representing
 	//whether or not a given file path exists.
 	//https://stackoverflow.com/questions/4316442/stdofstream-check-if-file-exists-before-writing
 	bool FileExists(const String &filename);
+
 	//Get the distance between two points.
 	float GetDistance(Vector2 a, Vector2 b);
+
 	//A method which returns an SDL_Rect which has been augmented by a given amount.
 	SDL_Rect GetExpandedRect(SDL_Rect rect, int expansion);
+
 	//Get a FloatRect value from a given SDL_Rect value.
 	FloatRect GetFloatRect(SDL_Rect sdlRect);
+
 	//Get an SDL_Rect value from a given FloatRect value.
 	SDL_Rect GetSDLRect(FloatRect frect);
+
 	//A method which returns an const char * value representing a given integer.
 	const char * Int_to_Str(int num);
+
 	float Lerp(float a, float b, float f);
 	Vector2 Lerp(Vector2 a, Vector2 b, float f);
 	FloatRect Lerp(FloatRect a, FloatRect b, float f);
+
 	//A method which returns a std::string representing a given number
 	//padded with 0s to show a given amount of digits.
 	String PadNumber(int num, int idealsize);
+
 	//A method which returns a random number between the two given values.
 	int RandomNumber(int min, int max);
+
 	//A method which rounds a float value and returns the resulting integer.
 	int Round(float value);
+
 	//Returns true if both points have the same memory address
 	//or if their X and Y values are identical.
 	bool SDL_PointEquals(SDL_Point* a, SDL_Point* b);
+
 	//Separates a string using a given value to separate the segments.
 	//https://stackoverflow.com/questions/14265581/parse-split-a-string-in-c-using-string-delimiter-standard-c
 	StdVec<String> Split(String str, String delimiter);
+
 	//A method which returns an const char * value representing a std::string.
 	const char * String_to_Str(String str);
+
 	//Converts a Vector2 into SDL_Point
 	//by rounding the X and Y values.
 	SDL_Point Vector2ToSDLPoint(Vector2 vec2);
+
 	//A method which loops until there is no audio playing on
 	//any sdl audio channels.
 	void WaitForMusicToStop();

--- a/BorisEngine2/BorisOperations.h
+++ b/BorisEngine2/BorisOperations.h
@@ -6,8 +6,15 @@
 #include <cstring>
 #include <sstream>
 /*#include <Windows.h>*/
-#include <SDL.h>
-#include <SDL_mixer.h>
+
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+  #include <SDL2/SDL_mixer.h>
+#else
+  #include <SDL.h>
+  #include <SDL_mixer.h>
+#endif
+
 #include <algorithm>
 #include <filesystem>
 #include <sys/stat.h>

--- a/BorisEngine2/BorisOperations.h
+++ b/BorisEngine2/BorisOperations.h
@@ -5,7 +5,7 @@
 #include "FloatRect.h"
 #include <cstring>
 #include <sstream>
-#include <Windows.h>
+/*#include <Windows.h>*/
 #include <SDL.h>
 #include <SDL_mixer.h>
 #include <algorithm>
@@ -15,8 +15,8 @@ namespace BorisOperations
 {
 	//Return "true" if b is true and "false" if b is false.
 	String BoolToString(bool b);
-	//A method which returns an LPCSTR value representing a character.
-	LPCSTR Char_to_LPCSTR(char c);
+	//A method which returns an const char * value representing a character.
+	const char * Char_to_Str(char c);
 	//A method which returns a std::string representing a character.
 	String CharToString(char c);
 	//A method which creates a given directory if
@@ -35,8 +35,8 @@ namespace BorisOperations
 	FloatRect GetFloatRect(SDL_Rect sdlRect);
 	//Get an SDL_Rect value from a given FloatRect value.
 	SDL_Rect GetSDLRect(FloatRect frect);
-	//A method which returns an LPCSTR value representing a given integer.
-	LPCSTR Int_to_LPCSTR(int num);
+	//A method which returns an const char * value representing a given integer.
+	const char * Int_to_Str(int num);
 	float Lerp(float a, float b, float f);
 	Vector2 Lerp(Vector2 a, Vector2 b, float f);
 	FloatRect Lerp(FloatRect a, FloatRect b, float f);
@@ -53,8 +53,8 @@ namespace BorisOperations
 	//Separates a string using a given value to separate the segments.
 	//https://stackoverflow.com/questions/14265581/parse-split-a-string-in-c-using-string-delimiter-standard-c
 	StdVec<String> Split(String str, String delimiter);
-	//A method which returns an LPCSTR value representing a std::string.
-	LPCSTR String_to_LPCSTR(String str);
+	//A method which returns an const char * value representing a std::string.
+	const char * String_to_Str(String str);
 	//Converts a Vector2 into SDL_Point
 	//by rounding the X and Y values.
 	SDL_Point Vector2ToSDLPoint(Vector2 vec2);

--- a/BorisEngine2/BorisOperations.h
+++ b/BorisEngine2/BorisOperations.h
@@ -9,6 +9,7 @@
 #include <SDL.h>
 #include <SDL_mixer.h>
 #include <algorithm>
+#include <filesystem>
 
 //A namespace used to contain a bunch of miscellaneous subroutines.
 namespace BorisOperations

--- a/BorisEngine2/BorisOperations.h
+++ b/BorisEngine2/BorisOperations.h
@@ -10,6 +10,7 @@
 #include <SDL_mixer.h>
 #include <algorithm>
 #include <filesystem>
+#include <sys/stat.h>
 
 //A namespace used to contain a bunch of miscellaneous subroutines.
 namespace BorisOperations

--- a/BorisEngine2/CMakeLists.txt
+++ b/BorisEngine2/CMakeLists.txt
@@ -73,3 +73,5 @@ include_directories(
          ${SDL2_MIXER_INCLUDE_DIR}
          )
 
+install(TARGETS BorisEngine BorisEngine_static)
+

--- a/BorisEngine2/CMakeLists.txt
+++ b/BorisEngine2/CMakeLists.txt
@@ -3,7 +3,31 @@ cmake_minimum_required(VERSION 3.1)
 
 project(BorisEngine)
 
-add_library(libBorisEngine.so SHARED
+add_library(libBorisEngine SHARED
+            BorisConsoleManager.cpp
+            BorisExternalInterface.cpp
+            BorisOperations.cpp
+            CSRand.cpp
+            DigitSprite.cpp
+            ExternalResourceManager.cpp
+            Font.cpp
+            FontManager.cpp
+            Game.cpp
+            Line.cpp
+            PointsCounter.cpp
+            Scene.cpp
+            SceneManager.cpp
+            SDL_Window_Manager.cpp
+            Sound.cpp
+            SoundManager.cpp
+            SoundWrap.cpp
+            Sprite.cpp
+            Texture.cpp
+            TextureManager.cpp
+            ThreadManager.cpp
+            Util.cpp)
+
+add_library(libBorisEngine_static STATIC
             BorisConsoleManager.cpp
             BorisExternalInterface.cpp
             BorisOperations.cpp
@@ -33,11 +57,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${BorisEngine_SOURCE_DIR}/cmake-find
 # Try uncommenting the following two lines if CMake build fails:
 #SET(CMAKE_CXX_COMPILER /usr/bin/g++)
 
-set_property(TARGET libBorisEngine.so PROPERTY CXX_STANDARD 17)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+set_property(TARGET libBorisEngine PROPERTY CXX_STANDARD 17)
+set_property(TARGET libBorisEngine_static PROPERTY CXX_STANDARD 17)
 
 find_package(SDL2 REQUIRED)
 find_package(SDL2_ttf REQUIRED)

--- a/BorisEngine2/CMakeLists.txt
+++ b/BorisEngine2/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.1)
 
 project(BorisEngine)
 
-add_library(libBorisEngine SHARED
+add_library(BorisEngine SHARED
             BorisConsoleManager.cpp
             BorisExternalInterface.cpp
             BorisOperations.cpp
@@ -27,7 +27,7 @@ add_library(libBorisEngine SHARED
             ThreadManager.cpp
             Util.cpp)
 
-add_library(libBorisEngine_static STATIC
+add_library(BorisEngine_static STATIC
             BorisConsoleManager.cpp
             BorisExternalInterface.cpp
             BorisOperations.cpp
@@ -57,8 +57,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${BorisEngine_SOURCE_DIR}/cmake-find
 # Try uncommenting the following two lines if CMake build fails:
 #SET(CMAKE_CXX_COMPILER /usr/bin/g++)
 
-set_property(TARGET libBorisEngine PROPERTY CXX_STANDARD 17)
-set_property(TARGET libBorisEngine_static PROPERTY CXX_STANDARD 17)
+set_property(TARGET BorisEngine PROPERTY CXX_STANDARD 17)
+set_property(TARGET BorisEngine_static PROPERTY CXX_STANDARD 17)
 
 find_package(SDL2 REQUIRED)
 find_package(SDL2_ttf REQUIRED)

--- a/BorisEngine2/CMakeLists.txt
+++ b/BorisEngine2/CMakeLists.txt
@@ -1,0 +1,54 @@
+
+cmake_minimum_required(VERSION 3.1)
+
+project(BorisEngine)
+
+add_library(libBorisEngine.so SHARED
+            BorisConsoleManager.cpp
+            BorisExternalInterface.cpp
+            BorisOperations.cpp
+            CSRand.cpp
+            DigitSprite.cpp
+            ExternalResourceManager.cpp
+            Font.cpp
+            FontManager.cpp
+            Game.cpp
+            Line.cpp
+            PointsCounter.cpp
+            Scene.cpp
+            SceneManager.cpp
+            SDL_Window_Manager.cpp
+            Sound.cpp
+            SoundManager.cpp
+            SoundWrap.cpp
+            Sprite.cpp
+            Texture.cpp
+            TextureManager.cpp
+            ThreadManager.cpp
+            Util.cpp)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${BorisEngine_SOURCE_DIR}/cmake-find-modules")
+
+# TODO set compilers?
+# Try uncommenting the following two lines if CMake build fails:
+#SET(CMAKE_CXX_COMPILER /usr/bin/g++)
+
+set_property(TARGET libBorisEngine.so PROPERTY CXX_STANDARD 17)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(SDL2 REQUIRED)
+find_package(SDL2_ttf REQUIRED)
+find_package(SDL2_mixer REQUIRED)
+find_package(SDL2_image REQUIRED)
+
+include_directories(
+         ${BorisEngine_SOURCE_DIR}
+         ${SDL2_INCLUDE_DIRS}
+         ${SDL2_IMAGE_INCLUDE_DIR}
+         ${SDL2_TTF_INCLUDE_DIR}
+         ${SDL2_MIXER_INCLUDE_DIR}
+         )
+

--- a/BorisEngine2/Font.cpp
+++ b/BorisEngine2/Font.cpp
@@ -1,13 +1,13 @@
 #include "Font.h"
 
-BorisConsoleManager* Font::BorisConsoleManager = BorisConsoleManager::Instance();
+BorisConsoleManager* Font::borisConsoleManager = BorisConsoleManager::Instance();
 
-Font::Font(LPCSTR filename, int fontSize,SDL_Renderer* _renderer) : Font(filename,fontSize,_renderer,{0,0,0,0},{255,255,255,255})
+Font::Font(const char *filename, int fontSize,SDL_Renderer* _renderer) : Font(filename,fontSize,_renderer,{0,0,0,0},{255,255,255,255})
 {
 
 }
 
-Font::Font(LPCSTR filename, int fontSize, SDL_Renderer* _renderer, SDL_Color text_colour, SDL_Color background_colour)
+Font::Font(const char *filename, int fontSize, SDL_Renderer* _renderer, SDL_Color text_colour, SDL_Color background_colour)
 {
 	renderer = _renderer;
 	ttfFont = TTF_OpenFont(filename, fontSize);
@@ -17,7 +17,7 @@ Font::Font(LPCSTR filename, int fontSize, SDL_Renderer* _renderer, SDL_Color tex
 	{
 		ttfFont = {};
 		String str = " Failed to load \"" + String(filename) + "\" font : " + String(SDL_GetError());
-		BorisConsoleManager->Print(str);
+		borisConsoleManager->Print(str);
 	}
 }
 
@@ -27,7 +27,7 @@ Font::~Font()
 	ttfFont = NULL;
 }
 
-Texture* Font::CreateTextTexture(LPCSTR text, TextType text_type)
+Texture* Font::CreateTextTexture(const char *text, TextType text_type)
 {
 	SDL_Surface* surface = NULL;
 	if (ttfFont)
@@ -59,7 +59,7 @@ Texture* Font::CreateTextTexture(LPCSTR text, TextType text_type)
 
 Texture* Font::CreateTextTexture(String text, TextType text_type)
 {
-	return CreateTextTexture(BorisOperations::String_to_LPCSTR(text), text_type);
+	return CreateTextTexture(BorisOperations::String_to_Str(text), text_type);
 }
 
 TTF_Font* Font::GetFont()

--- a/BorisEngine2/Font.h
+++ b/BorisEngine2/Font.h
@@ -2,7 +2,7 @@
 #define _FONT_H
 
 #include<SDL_ttf.h>
-#include<Windows.h>
+/*#include<Windows.h>*/
 #include<iostream>
 #include"Texture.h"
 #include "BorisConsoleManager.h"
@@ -15,13 +15,13 @@ class Font
 {
 	public:
 		//Constructor, takes file path of font to be loaded, size of the font, and a pointer to the sdl renderer.
-		Font(LPCSTR filename,int fontSize,SDL_Renderer* _renderer);
+		Font(const char *filename,int fontSize,SDL_Renderer* _renderer);
 		//Constructor, takes the same parameters as the previous one but also takes sdl colours representing the foreground and background colours.
-		Font(LPCSTR filename, int fontSize, SDL_Renderer* _renderer, SDL_Color text_colour, SDL_Color background_colour);
+		Font(const char *filename, int fontSize, SDL_Renderer* _renderer, SDL_Color text_colour, SDL_Color background_colour);
 		//Destructor method.
 		~Font();
 		//A method which creates a texture resembling given text and displays it differently depending on the given "TextType".
-		Texture* CreateTextTexture(LPCSTR text, TextType text_type);
+		Texture* CreateTextTexture(const char *text, TextType text_type);
 		//A method which creates a texture resembling given text and displays it differently depending on the given "TextType".
 		Texture* CreateTextTexture(String text, TextType text_type);
 		//Returns a pointer to the "TTF_Font" value which represents the font information in the context of the sdl library.
@@ -30,7 +30,7 @@ class Font
 	private:
 		//A value used for the background colour of the text.
 		SDL_Color backgroundColour;
-		static BorisConsoleManager* BorisConsoleManager;
+		static BorisConsoleManager* borisConsoleManager;
 		//A pointer to the sdl renderer used in the current window.
 		SDL_Renderer* renderer;
 		//A value used for the foreground colour of the text.

--- a/BorisEngine2/Font.h
+++ b/BorisEngine2/Font.h
@@ -1,10 +1,17 @@
 #ifndef _FONT_H
 #define _FONT_H
 
-#include<SDL_ttf.h>
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+  #include <SDL2/SDL_ttf.h>
+#else
+  #include <SDL.h>
+  #include <SDL_ttf.h>
+#endif
+
 /*#include<Windows.h>*/
-#include<iostream>
-#include"Texture.h"
+#include <iostream>
+#include "Texture.h"
 #include "BorisConsoleManager.h"
 
 //Create an enumeration for the different possible ways of displaying text.

--- a/BorisEngine2/FontManager.cpp
+++ b/BorisEngine2/FontManager.cpp
@@ -1,14 +1,14 @@
 #include "FontManager.h"
 
 FontManager* FontManager::_instance = NULL;
-BorisConsoleManager* FontManager::BorisConsoleManager = BorisConsoleManager::Instance();
+BorisConsoleManager* FontManager::borisConsoleManager = BorisConsoleManager::Instance();
 
 FontManager::FontManager()
 {
 	if (TTF_Init() != 0)
 	{
 		String str = "TTF_Init() Failed: " + String(SDL_GetError());
-		BorisConsoleManager->Print(str);
+		borisConsoleManager->Print(str);
 	}
 }
 

--- a/BorisEngine2/FontManager.h
+++ b/BorisEngine2/FontManager.h
@@ -24,7 +24,7 @@ class FontManager
 		static FontManager* _instance;
 		//A map using std::strings as keys and "Font" pointers as values.
 		Dictionary<String, Font*> fonts;
-		static BorisConsoleManager* BorisConsoleManager;
+		static BorisConsoleManager* borisConsoleManager;
 };
 
 #endif

--- a/BorisEngine2/Game.h
+++ b/BorisEngine2/Game.h
@@ -1,10 +1,16 @@
 #ifndef _GAME_H
 #define _GAME_H
 
-#include<SDL.h>
-#include<SDL_image.h>
-#include<iostream>
-#include"SceneManager.h"
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+  #include <SDL2/SDL_image.h>
+#else
+  #include <SDL.h>
+  #include <SDL_image.h>
+#endif
+
+#include <iostream>
+#include "SceneManager.h"
 #include "SDL_Window_Manager.h"
 #include "favicon.c"
 

--- a/BorisEngine2/Line.h
+++ b/BorisEngine2/Line.h
@@ -2,8 +2,15 @@
 #define _LINE_H
 
 #include "Renderable.h"
-#include "SDL_rect.h"
-#include "SDL_render.h"
+
+#ifdef __linux__
+  #include <SDL2/SDL_rect.h>
+  #include <SDL2/SDL_render.h>
+#else
+  #include <SDL_rect.h>
+  #include <SDL_render.h>
+#endif
+
 #include "BorisOperations.h"
 
 class Line : public Renderable

--- a/BorisEngine2/Makefile
+++ b/BorisEngine2/Makefile
@@ -1,0 +1,24 @@
+CC=g++
+
+# TODO separate flags for different build (Release and debug)
+CXXFLAGS=-g -Wall -Wextra -O2 -fPIC -std=c++17 # necessary for filesystem interface
+LIBS=-lstdc++fs
+
+all: BorisEngine_static BorisEngine_shared
+
+objs = BorisConsoleManager.o BorisExternalInterface.o \
+       BorisOperations.o CSRand.o DigitSprite.o       \
+       ExternalResourceManager.o FontManager.o Font.o Game.o \
+       Line.o PointsCounter.o SceneManager.o Scene.o \
+       SDL_Window_Manager.o SoundManager.o Sound.o SoundWrap.o \
+       Sprite.o TextureManager.o Texture.o ThreadManager.o Util.o
+
+BorisEngine_static: $(objs)
+	ar rcs libBorisEngine_static.a $(objs)
+
+BorisEngine_shared: $(objs)
+	$(CC) -shared -o libBorisEngine.so $(objs)
+
+%.o: %.c
+	$(CC) -c $< -o $@ $(CXXFLAGS)
+

--- a/BorisEngine2/Makefile
+++ b/BorisEngine2/Makefile
@@ -1,10 +1,11 @@
 CC=g++
+INCLUDE_DIR=/usr/local/include/SDL2/
 
 # TODO separate flags for different build (Release and debug)
 CXXFLAGS=-g -Wall -Wextra -O2 -fPIC -std=c++17 # necessary for filesystem interface
 LIBS=-lstdc++fs
 
-all: BorisEngine_static BorisEngine_shared
+all: libBorisEngine.a libBorisEngine.so
 
 objs = BorisConsoleManager.o BorisExternalInterface.o \
        BorisOperations.o CSRand.o DigitSprite.o       \
@@ -13,12 +14,152 @@ objs = BorisConsoleManager.o BorisExternalInterface.o \
        SDL_Window_Manager.o SoundManager.o Sound.o SoundWrap.o \
        Sprite.o TextureManager.o Texture.o ThreadManager.o Util.o
 
-BorisEngine_static: $(objs)
-	ar rcs libBorisEngine_static.a $(objs)
+PIC_objs = BorisConsoleManager_shared.o BorisExternalInterface_shared.o \
+       BorisOperations_shared.o CSRand_shared.o DigitSprite_shared.o       \
+       ExternalResourceManager_shared.o FontManager_shared.o Font_shared.o Game_shared.o \
+       Line_shared.o PointsCounter_shared.o SceneManager_shared.o Scene_shared.o \
+       SDL_Window_Manager_shared.o SoundManager_shared.o Sound_shared.o SoundWrap_shared.o \
+       Sprite_shared.o TextureManager_shared.o Texture_shared.o ThreadManager_shared.o Util_shared.o
 
-BorisEngine_shared: $(objs)
-	$(CC) -shared -o libBorisEngine.so $(objs)
+libBorisEngine.a: $(objs)
+	ar rcs $@ $(objs)
 
-%.o: %.c
-	$(CC) -c $< -o $@ $(CXXFLAGS)
+libBorisEngine.so: $(PIC_objs)
+	$(CC) -shared -o $@ $(PIC_objs)
+
+BorisConsoleManager_shared.o: BorisConsoleManager.h
+	$(CC) -c BorisConsoleManager.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+BorisExternalInterface_shared.o: BorisExternalInterface.h
+	$(CC) -c BorisExternalInterface.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+BorisOperations_shared.o: BorisOperations.h
+	$(CC) -c BorisOperations.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+CSRand_shared.o: CSRand.h
+	$(CC) -c CSRand.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+DigitSprite_shared.o: DigitSprite.h
+	$(CC) -c DigitSprite.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+ExternalResourceManager_shared.o: ExternalResourceManager.h
+	$(CC) -c ExternalResourceManager.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+FontManager_shared.o: FontManager.h
+	$(CC) -c FontManager.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+Font_shared.o: Font.h
+	$(CC) -c Font.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+Game_shared.o: Game.h
+	$(CC) -c Game.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+Line_shared.o: Line.h
+	$(CC) -c Line.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+PointsCounter_shared.o: PointsCounter.h
+	$(CC) -c PointsCounter.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+SceneManager_shared.o: SceneManager.h
+	$(CC) -c SceneManager.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+Scene_shared.o: Scene.h
+	$(CC) -c Scene.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+SDL_Window_Manager_shared.o: SDL_Window_Manager.h
+	$(CC) -c SDL_Window_Manager.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+SoundManager_shared.o: SoundManager.h
+	$(CC) -c SoundManager.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+Sound_shared.o: Sound.h
+	$(CC) -c Sound.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+SoundWrap_shared.o: SoundWrap.h
+	$(CC) -c SoundWrap.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+Sprite_shared.o: Sprite.h
+	$(CC) -c Sprite.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+TextureManager_shared.o: TextureManager.h
+	$(CC) -c TextureManager.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+Texture_shared.o: Texture.h
+	$(CC) -c Texture.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+ThreadManager_shared.o: ThreadManager.h
+	$(CC) -c ThreadManager.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+Util_shared.o: Util.h
+	$(CC) -c Util.cpp -o $@ $(CXXFLAGS) -fPIC -I $(INCLUDE_DIR)
+
+BorisConsoleManager.o: BorisConsoleManager.h
+	$(CC) -c BorisConsoleManager.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+BorisExternalInterface.o: BorisExternalInterface.h
+	$(CC) -c BorisExternalInterface.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+BorisOperations.o: BorisOperations.h
+	$(CC) -c BorisOperations.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+CSRand.o: CSRand.h
+	$(CC) -c CSRand.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+DigitSprite.o: DigitSprite.h
+	$(CC) -c DigitSprite.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+ExternalResourceManager.o: ExternalResourceManager.h
+	$(CC) -c ExternalResourceManager.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+FontManager.o: FontManager.h
+	$(CC) -c FontManager.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+Font.o: Font.h
+	$(CC) -c Font.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+Game.o: Game.h
+	$(CC) -c Game.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+Line.o: Line.h
+	$(CC) -c Line.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+PointsCounter.o: PointsCounter.h
+	$(CC) -c PointsCounter.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+SceneManager.o: SceneManager.h
+	$(CC) -c SceneManager.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+Scene.o: Scene.h
+	$(CC) -c Scene.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+SDL_Window_Manager.o: SDL_Window_Manager.h
+	$(CC) -c SDL_Window_Manager.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+SoundManager.o: SoundManager.h
+	$(CC) -c SoundManager.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+Sound.o: Sound.h
+	$(CC) -c Sound.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+SoundWrap.o: SoundWrap.h
+	$(CC) -c SoundWrap.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+Sprite.o: Sprite.h
+	$(CC) -c Sprite.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+TextureManager.o: TextureManager.h
+	$(CC) -c TextureManager.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+Texture.o: Texture.h
+	$(CC) -c Texture.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+ThreadManager.o: ThreadManager.h
+	$(CC) -c ThreadManager.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+Util.o: Util.h
+	$(CC) -c Util.cpp -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
+
+# TODO figure out the implicit pattern to capture all of these component .o files?
+#%.o : %.c
+#	$(CC) -c $< -o $@ $(CXXFLAGS) -I $(INCLUDE_DIR)
 

--- a/BorisEngine2/SDL_Window_Manager.cpp
+++ b/BorisEngine2/SDL_Window_Manager.cpp
@@ -1,6 +1,6 @@
 #include "SDL_Window_Manager.h"
 
-BorisConsoleManager* SDL_Window_Manager::BorisConsoleManager = BorisConsoleManager::Instance();
+BorisConsoleManager* SDL_Window_Manager::borisConsoleManager = BorisConsoleManager::Instance();
 
 SDL_Window_Manager* SDL_Window_Manager::instance = NULL;
 
@@ -23,10 +23,10 @@ void SDL_Window_Manager::CheckSDLError(int line = -1)
 	String error = SDL_GetError();
 	if (error != "")
 	{
-		BorisConsoleManager->Print("SLD Error : " + error);
+		borisConsoleManager->Print("SLD Error : " + error);
 		if (line != -1)
 		{
-			BorisConsoleManager->Print("Line : " + std::to_string(line));
+			borisConsoleManager->Print("Line : " + std::to_string(line));
 		}
 		SDL_ClearError();
 	}
@@ -57,7 +57,7 @@ bool SDL_Window_Manager::initWND(String windowTitle, int width, int height, Icon
 	// Initialize SDL's Video subsystem
 	if (SDL_Init(SDL_INIT_VIDEO) < 0)
 	{
-		BorisConsoleManager->Print("Failed to load SDL");
+		borisConsoleManager->Print("Failed to load SDL");
 		return false;
 	}
 	mainWindow = SDL_CreateWindow(windowTitle.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
@@ -65,7 +65,7 @@ bool SDL_Window_Manager::initWND(String windowTitle, int width, int height, Icon
 	// Check that everything worked out okay
 	if (!mainWindow)
 	{
-		BorisConsoleManager->Print("Unable to create window.");
+		borisConsoleManager->Print("Unable to create window.");
 		CheckSDLError(__LINE__);
 		return false;
 	}
@@ -73,12 +73,12 @@ bool SDL_Window_Manager::initWND(String windowTitle, int width, int height, Icon
 	sdlRenderer = SDL_CreateRenderer(mainWindow, -1, 0);
 	if (sdlRenderer)
 	{
-		BorisConsoleManager->Print("Renderer creation succeeded");
+		borisConsoleManager->Print("Renderer creation succeeded");
 		SDL_SetRenderDrawColor(sdlRenderer, 0, 0, 100, 255);
 		SetSDLIcon(icon);
 		return true;
 	}
-	BorisConsoleManager->Print("Renderer creation failed");
+	borisConsoleManager->Print("Renderer creation failed");
 	return false;
 }
 

--- a/BorisEngine2/SDL_Window_Manager.h
+++ b/BorisEngine2/SDL_Window_Manager.h
@@ -41,7 +41,7 @@ class SDL_Window_Manager
 		SDL_Window *mainWindow;
 		//A pointer to the SDL renderer.
 		SDL_Renderer* sdlRenderer;
-		static BorisConsoleManager* BorisConsoleManager;
+		static BorisConsoleManager* borisConsoleManager;
 
 };
 

--- a/BorisEngine2/SDL_Window_Manager.h
+++ b/BorisEngine2/SDL_Window_Manager.h
@@ -1,8 +1,14 @@
 #ifndef  _SDLWINDOWMANAGER_H
 #define _SDLWINDOWMANAGER_H
 
-#include <SDL.h>
-#include <SDL_image.h>
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+  #include <SDL2/SDL_image.h>
+#else
+  #include <SDL.h>
+  #include <SDL_image.h>
+#endif
+
 #include "favicon.c"
 #include "BorisConsoleManager.h"
 #include "BorisOperations.h"

--- a/BorisEngine2/SceneManager.cpp
+++ b/BorisEngine2/SceneManager.cpp
@@ -2,7 +2,7 @@
 
 SceneManager* SceneManager::_instance = NULL;
 
-BorisConsoleManager* SceneManager::BorisConsoleManager = BorisConsoleManager::Instance();
+BorisConsoleManager* SceneManager::borisConsoleManager = BorisConsoleManager::Instance();
 
 SceneManager::SceneManager()
 {
@@ -41,6 +41,6 @@ void SceneManager::AddScene(String scenename, Scene* scene)
 	}
 	if (scenename == "")
 	{
-		BorisConsoleManager->Print("Using an empty std::string for a scene name is illegal as this would create a runtime error. Please use a substantive name.");
+		borisConsoleManager->Print("Using an empty std::string for a scene name is illegal as this would create a runtime error. Please use a substantive name.");
 	}
 }

--- a/BorisEngine2/SceneManager.h
+++ b/BorisEngine2/SceneManager.h
@@ -29,7 +29,7 @@ class SceneManager
 		//A map which uses std::strings (scene names) as keys 
 		//and "Scene" pointers as values.
 		Dictionary<String, Scene*> scenes;
-		static BorisConsoleManager* BorisConsoleManager;
+		static BorisConsoleManager* borisConsoleManager;
 };
 
 #endif // !_SCENEMANAGER_H

--- a/BorisEngine2/Sound.cpp
+++ b/BorisEngine2/Sound.cpp
@@ -1,8 +1,8 @@
 #include "Sound.h"
 
-BorisConsoleManager* Sound::BorisConsoleManager = BorisConsoleManager::Instance();
+BorisConsoleManager* Sound::borisConsoleManager = BorisConsoleManager::Instance();
 
-Sound::Sound(LPCSTR filename, SoundType sound_type)
+Sound::Sound(const char *filename, SoundType sound_type)
 {
 	soundType = sound_type;
 	switch (soundType)
@@ -13,29 +13,29 @@ Sound::Sound(LPCSTR filename, SoundType sound_type)
 			if (sound == 0)
 			{
 				String str = "Sound FX '" + String(filename) + "' could not be loaded. " + String(SDL_GetError());
-				BorisConsoleManager->Print(str);
+				borisConsoleManager->Print(str);
 			}
 			else
 			{
 				Mix_VolumeChunk(sound, Util::GetInstance()->GetSFXVolume());
 				String str = "Sound FX '" + String(filename) + "' was successfully loaded. ";
-				BorisConsoleManager->Print(str);
+				borisConsoleManager->Print(str);
 			}
 			break;
 		}
 		case MUSIC:
 		{
 			music = Mix_LoadMUS(filename);
-			BorisConsoleManager->Print(String(Mix_GetError()));
+			borisConsoleManager->Print(String(Mix_GetError()));
 			if (!music)
 			{
 				String str = "Music '" + String(filename) + "' could not be loaded. " + String(SDL_GetError());
-				BorisConsoleManager->Print(str);
+				borisConsoleManager->Print(str);
 			}
 			else
 			{
 				String str = "Music '" + String(filename) + "' was successfully loaded. ";
-				BorisConsoleManager->Print(str);
+				borisConsoleManager->Print(str);
 			}
 			break;
 		}

--- a/BorisEngine2/Sound.h
+++ b/BorisEngine2/Sound.h
@@ -2,7 +2,7 @@
 #define _SOUND_H
 
 #include <stdlib.h>
-#include <Windows.h>
+/*#include <Windows.h>*/
 #include <iostream>
 #include <cstdlib>
 #include <SDL.h>
@@ -23,7 +23,7 @@ class Sound
 {
 	public:
 		//Constructor, takes the file path of an audio file and the type of the audio.
-		Sound(LPCSTR filename, SoundType sound_type);
+		Sound(const char *filename, SoundType sound_type);
 		//Destructor method.
 		~Sound();
 		//A method which returns the SoundType of this instance.
@@ -46,7 +46,7 @@ class Sound
 		Mix_Music* music = NULL;
 
 		static int play(void* data);
-		static BorisConsoleManager* BorisConsoleManager;
+		static BorisConsoleManager* borisConsoleManager;
 };
 
 #endif // ! _SOUND_H

--- a/BorisEngine2/Sound.h
+++ b/BorisEngine2/Sound.h
@@ -5,9 +5,15 @@
 /*#include <Windows.h>*/
 #include <iostream>
 #include <cstdlib>
-#include <SDL.h>
-#include<SDL.h>
-#include<SDL_mixer.h>
+
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+  #include <SDL2/SDL_mixer.h>
+#else
+  #include <SDL.h>
+  #include <SDL_mixer.h>
+#endif
+
 #include <string>
 #include <iostream>
 #include <fstream>

--- a/BorisEngine2/SoundManager.cpp
+++ b/BorisEngine2/SoundManager.cpp
@@ -2,7 +2,7 @@
 
 SoundManager* SoundManager::_instance = NULL;
 
-BorisConsoleManager* SoundManager::BorisConsoleManager = BorisConsoleManager::Instance();
+BorisConsoleManager* SoundManager::borisConsoleManager = BorisConsoleManager::Instance();
 
 SoundManager::SoundManager()
 {
@@ -14,13 +14,13 @@ bool SoundManager::Initialise()
 	if (SDL_Init(SDL_INIT_AUDIO) != 0)
 	{
 		String str = "SDL_Init_AUDIO Failed: " + String(SDL_GetError());
-		BorisConsoleManager->Print(str);
+		borisConsoleManager->Print(str);
 		return false;
 	}
 	if (Mix_OpenAudio(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, 2, 4096) != 0)
 	{
 		String str = "Mix_OpenAudio Failed: " + String(SDL_GetError());
-		BorisConsoleManager->Print(str);
+		borisConsoleManager->Print(str);
 		return false;
 	}
 	return true;
@@ -52,7 +52,7 @@ Sound* SoundManager::GetSound(String soundname)//(LPCSTR soundname)
 	return NULL;
 }
 
-void SoundManager::AddSound(String soundname, LPCSTR filename, SoundType soundtype)
+void SoundManager::AddSound(String soundname, const char *filename, SoundType soundtype)
 {
 	if (!GetSound(soundname))
 	{

--- a/BorisEngine2/SoundManager.h
+++ b/BorisEngine2/SoundManager.h
@@ -1,11 +1,13 @@
 #ifndef _SOUNDMANAGER_H
 #define _SOUNDMANAGER_H
 
-#include<SDL_mixer.h>
-#include<iostream>
-#include<map>
-#include<vector>
-#include"Sound.h"
+#include <SDL_mixer.h>
+#include <iostream>
+#include <map>
+#include <vector>
+
+#include "BorisConsoleManager.h"
+#include "Sound.h"
 
 //Create a class used to store pointers to instances of "Sound" so that they can be easily accessed when necessary.
 class SoundManager
@@ -16,7 +18,7 @@ class SoundManager
 		//A method which returns a pointer to the only instance of this class.
 		static SoundManager* GetInstance();
 		//Add a sound using a given file path and sound type.
-		void AddSound(String soundName, LPCSTR fileName, SoundType soundtype);
+		void AddSound(String soundName, const char *fileName, SoundType soundtype);
 		//Return a pointer to an instance of "Sound" using a given name.
 		Sound* GetSound(String soundName);
 		//A method that deletes all the stored sounds.
@@ -33,7 +35,7 @@ class SoundManager
 		//A method which attempts to initialise the instance and returns a boolean
 		//representing whether or not it was successful.
 		bool Initialise();
-		static BorisConsoleManager* BorisConsoleManager;
+		static BorisConsoleManager* borisConsoleManager;
 };
 
 #endif

--- a/BorisEngine2/SoundManager.h
+++ b/BorisEngine2/SoundManager.h
@@ -1,7 +1,14 @@
 #ifndef _SOUNDMANAGER_H
 #define _SOUNDMANAGER_H
 
-#include <SDL_mixer.h>
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+  #include <SDL2/SDL_mixer.h>
+#else
+  #include <SDL.h>
+  #include <SDL_mixer.h>
+#endif
+
 #include <iostream>
 #include <map>
 #include <vector>

--- a/BorisEngine2/SoundWrap.h
+++ b/BorisEngine2/SoundWrap.h
@@ -1,8 +1,8 @@
 #ifndef  _SOUNDWRAP_H
 #define _SOUNDWRAP_H
 
-#include<SDL.h>
-#include<SDL_mixer.h>
+#include <SDL.h>
+#include <SDL_mixer.h>
 
 //An enumeration which represents the 2 different types of audio.
 enum SoundType { SFX, MUSIC };

--- a/BorisEngine2/SoundWrap.h
+++ b/BorisEngine2/SoundWrap.h
@@ -1,8 +1,13 @@
 #ifndef  _SOUNDWRAP_H
 #define _SOUNDWRAP_H
 
-#include <SDL.h>
-#include <SDL_mixer.h>
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+  #include <SDL2/SDL_mixer.h>
+#else
+  #include <SDL.h>
+  #include <SDL_mixer.h>
+#endif
 
 //An enumeration which represents the 2 different types of audio.
 enum SoundType { SFX, MUSIC };

--- a/BorisEngine2/Sprite.cpp
+++ b/BorisEngine2/Sprite.cpp
@@ -40,7 +40,8 @@ Sprite::~Sprite()
 
 bool Sprite::CollidesWith(SDL_Rect* boundary)
 {
-	return SDL_HasIntersection(&GetPosition(), boundary) != 0;
+	const SDL_Rect myCurrentPos = GetPosition();
+	return SDL_HasIntersection(&myCurrentPos, boundary) != 0;
 }
 
 bool Sprite::CollidesWith(Sprite* otherSprite)
@@ -49,12 +50,14 @@ bool Sprite::CollidesWith(Sprite* otherSprite)
 	{
 		return false;
 	}
-	return CollidesWith(&BorisOperations::GetExpandedRect(otherSprite->GetPosition(), 2));
+	SDL_Rect expandedRect = BorisOperations::GetExpandedRect(otherSprite->GetPosition(), 2);
+	return CollidesWith(&expandedRect);
 }
 
 bool Sprite::Clicked(SDL_Point* mouseposition)
 {
-	return IsActive() && SDL_PointInRect(mouseposition, &GetPosition());
+	const SDL_Rect myCurrentPos = GetPosition();
+	return IsActive() && SDL_PointInRect(mouseposition, &myCurrentPos);
 }
 
 Vector2 Sprite::Force()
@@ -168,11 +171,13 @@ void Sprite::Render()
 	//RenderRotated(&dimension, &GetPosition());
 	if (!rotation)
 	{
-		Render(&dimension, &GetPosition());
+		SDL_Rect myCurrentPos = GetPosition();
+		Render(&dimension, &myCurrentPos);
 	}
 	else
 	{
-		RenderRotated(&dimension, &GetPosition());
+		SDL_Rect myCurrentPos = GetPosition();
+		RenderRotated(&dimension, &myCurrentPos);
 	}
 }
 
@@ -192,11 +197,13 @@ void Sprite::RenderRotated(SDL_Rect* source, SDL_Rect* dest)
 {
 	if (GetSpriteType() == REGULAR)
 	{
-		texture->Render(source, dest, rotation, &GetCentre());
+		SDL_Point myCurrentCenter = GetCentre();
+		texture->Render(source, dest, rotation, &myCurrentCenter);
 	}
 	else
 	{
-		texture->Render(NULL, NULL, rotation, &GetCentre());
+		SDL_Point myCurrentCenter = GetCentre();
+		texture->Render(NULL, NULL, rotation, &myCurrentCenter);
 	}
 }
 

--- a/BorisEngine2/Sprite.h
+++ b/BorisEngine2/Sprite.h
@@ -1,11 +1,16 @@
 #ifndef  _SPRITE_H
 #define _SPRITE_H
 
-#include<SDL.h>
-#include"Texture.h"
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+#else
+  #include <SDL.h>
+#endif
+
+#include "Texture.h"
 #include "TextureManager.h"
-#include"BorisOperations.h"
-#include"Util.h"
+#include "BorisOperations.h"
+#include "Util.h"
 #include "SoundManager.h"
 #include "Renderable.h"
 #include "Animation.h"

--- a/BorisEngine2/Texture.cpp
+++ b/BorisEngine2/Texture.cpp
@@ -2,7 +2,7 @@
 
 BorisConsoleManager* Texture::borisConsoleManager = BorisConsoleManager::Instance();
 
-Texture::Texture(LPCSTR filename, SDL_Renderer* renderer) : Texture(IMG_LoadTexture(renderer,filename),renderer)
+Texture::Texture(const char *filename, SDL_Renderer* renderer) : Texture(IMG_LoadTexture(renderer,filename),renderer)
 {
 
 }

--- a/BorisEngine2/Texture.h
+++ b/BorisEngine2/Texture.h
@@ -8,7 +8,7 @@
 
 // Windows & SDL 
 #include <stdlib.h>
-#include <Windows.h>
+/*#include <Windows.h>*/
 #include <iostream>
 #include <string>
 #include <ctime>
@@ -31,7 +31,7 @@ class Texture
 {
 	public:
 		//Constructor, loads an image from given file path.
-		Texture(LPCSTR theFilename, SDL_Renderer *theRenderer);
+		Texture(const char *filename, SDL_Renderer *theRenderer);
 		//Constructor, sets the sdl texture to the given value.
 		Texture(SDL_Texture* texture, SDL_Renderer* theRenderer);
 		//Constructor, sets the sdl texture to the given value, checks if texture is template or not.

--- a/BorisEngine2/Texture.h
+++ b/BorisEngine2/Texture.h
@@ -13,11 +13,20 @@
 #include <string>
 #include <ctime>
 #include <cstdlib>
-#include <SDL.h>
-// Image Texture loading library
-#include <SDL_image.h>
-// Font loading library
-#include <SDL_ttf.h>
+
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+
+  // Image Texture loading library
+  #include <SDL2/SDL_image.h>
+
+  // Font loading library
+  #include <SDL2/SDL_ttf.h>
+#else
+  #include <SDL.h>
+  #include <SDL_image.h>
+  #include <SDL_ttf.h>
+#endif
 
 // STL Container & Algorithms
 #include <vector>

--- a/BorisEngine2/TextureManager.cpp
+++ b/BorisEngine2/TextureManager.cpp
@@ -2,7 +2,7 @@
 
 TextureManager* TextureManager::_instance = NULL;
 
-BorisConsoleManager* TextureManager::BorisConsoleManager = BorisConsoleManager::Instance();
+BorisConsoleManager* TextureManager::borisConsoleManager = BorisConsoleManager::Instance();
 
 TextureManager::TextureManager()
 {
@@ -23,7 +23,7 @@ TextureManager* TextureManager::getInstance()
 	return _instance;
 }
 
-Texture* TextureManager::AddTexture(String textureName, LPCSTR filename)//(LPCSTR textureName, LPCSTR filename)
+Texture* TextureManager::AddTexture(String textureName, const char *filename)//(LPCSTR textureName, LPCSTR filename)
 {
 	Texture* texture = new Texture(filename, sdlRenderer);
 	return AddTexture(textureName, texture);
@@ -38,7 +38,7 @@ Texture* TextureManager::AddTexture(String textureName, Texture* texture)//(LPCS
 		return texture;
 	}
 	String str = "Unable to add" + textureName + "because a texture of that name has already been added.";
-	BorisConsoleManager->Print(str);
+	borisConsoleManager->Print(str);
 	return texture;
 }
 

--- a/BorisEngine2/TextureManager.h
+++ b/BorisEngine2/TextureManager.h
@@ -9,11 +9,19 @@
 #include <ctime>
 #include <cstdlib>
 
-#include <SDL.h>
-// Image Texture loading library
-#include <SDL_image.h>
-// Font loading library
-#include <SDL_ttf.h>
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+
+  // Image Texture loading library
+  #include <SDL2/SDL_image.h>
+
+  // Font loading library
+  #include <SDL2/SDL_ttf.h>
+#else
+  #include <SDL.h>
+  #include <SDL_image.h>
+  #include <SDL_ttf.h>
+#endif
 
 // STL Container & Algorithms
 #include <vector>

--- a/BorisEngine2/TextureManager.h
+++ b/BorisEngine2/TextureManager.h
@@ -3,11 +3,12 @@
 
 // Windows & SDL 
 #include <stdlib.h>
-#include <Windows.h>
+/*#include <Windows.h>*/
 #include <iostream>
 #include <string>
 #include <ctime>
 #include <cstdlib>
+
 #include <SDL.h>
 // Image Texture loading library
 #include <SDL_image.h>
@@ -19,7 +20,8 @@
 #include <map>
 #include <algorithm>
 
-#include"Texture.h"
+#include "BorisConsoleManager.h"
+#include "Texture.h"
 
 //Create a class used to store pointers to instances of "Texture" so that they can be easily accessed when necessary.
 class TextureManager
@@ -30,7 +32,7 @@ class TextureManager
 		static TextureManager* getInstance();
 		//A method which adds a texture by loading one from
 		//a given file path.
-		Texture* AddTexture(String texturename, LPCSTR theFilename);
+		Texture* AddTexture(String texturename, const char *filename);
 		//A method which adds a given texture.
 		Texture* AddTexture(String texturename, Texture* texture);
 		//A method which returns a pointer to an instance
@@ -58,7 +60,7 @@ class TextureManager
 		Dictionary<String, Texture*> textureList;
 		//The SDL renderer.
 		SDL_Renderer* sdlRenderer;
-		static BorisConsoleManager* BorisConsoleManager;
+		static BorisConsoleManager* borisConsoleManager;
 };
 
 #endif

--- a/BorisEngine2/ThreadManager.cpp
+++ b/BorisEngine2/ThreadManager.cpp
@@ -40,7 +40,7 @@ void ThreadManager::Dispose()
 void ThreadManager::RunThread(SDL_ThreadFunction method, void* param)
 {
 	String* n = new String("Thread #" + std::to_string(ThreadCount()));
-	LPCSTR name = BorisOperations::String_to_LPCSTR(*n);
-	SDL_Thread* threadID = SDL_CreateThread(method, name, param);
+/*	LPCSTR name = BorisOperations::String_to_Str(*n);*/ // TODO delete or at least make this Windows-specific
+	SDL_Thread* threadID = SDL_CreateThread(method, n->c_str(), param);
 	threads.push_back(threadID);
 }

--- a/BorisEngine2/ThreadManager.h
+++ b/BorisEngine2/ThreadManager.h
@@ -1,7 +1,12 @@
 #ifndef _THREAD_MANAGER_H
 #define _THREAD_MANAGER_H
 
-#include "SDL.h"
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+#else
+  #include <SDL.h>
+#endif
+
 #include "BorisOperations.h"
 #include <iostream>
 #include <vector>

--- a/BorisEngine2/Util.cpp
+++ b/BorisEngine2/Util.cpp
@@ -2,7 +2,7 @@
 
 Util* Util::_instance = NULL;
 
-BorisConsoleManager* Util::BorisConsoleManager = BorisConsoleManager::Instance();
+BorisConsoleManager* Util::borisConsoleManager = BorisConsoleManager::Instance();
 
 Util::Util()
 {
@@ -48,7 +48,7 @@ int Util::GetSFXVolume()
 void Util::SetSFXVolume(int volume)
 {
 	sfxvolume = volume;
-	BorisConsoleManager->Print("SFX volume has been set to " + std::to_string(volume) + ".");
+	borisConsoleManager->Print("SFX volume has been set to " + std::to_string(volume) + ".");
 }
 
 int Util::GetMusicVolume()
@@ -60,7 +60,7 @@ void Util::SetMusicVolume(int volume)
 {
 	musicvolume = volume;
 	Mix_VolumeMusic(volume);
-	BorisConsoleManager->Print("Music volume has been set to " + std::to_string(volume));
+	borisConsoleManager->Print("Music volume has been set to " + std::to_string(volume));
 }
 
 String Util::GetCurrentMusic()
@@ -80,7 +80,7 @@ void Util::IncreaseHealth(double amount)
 	(
 		health < 0 ? 0 : health
 	);
-	BorisConsoleManager->Print("Current health is: " + std::to_string(health) + ".");
+	borisConsoleManager->Print("Current health is: " + std::to_string(health) + ".");
 }
 
 double Util::GetHealth()

--- a/BorisEngine2/Util.h
+++ b/BorisEngine2/Util.h
@@ -1,8 +1,14 @@
 #ifndef _UTIL_H
 #define _UTIL_H
 
-#include <SDL.h>
-#include <SDL_mixer.h>
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+  #include <SDL2/SDL_mixer.h>
+#else
+  #include <SDL.h>
+  #include <SDL_mixer.h>
+#endif
+
 #include <string>
 #include <iostream>
 /*#include <Windows.h>*/

--- a/BorisEngine2/Util.h
+++ b/BorisEngine2/Util.h
@@ -5,7 +5,7 @@
 #include <SDL_mixer.h>
 #include <string>
 #include <iostream>
-#include <Windows.h>
+/*#include <Windows.h>*/
 #include "BorisConsoleManager.h"
 
 //A class used to contain gameplay information and settings.
@@ -59,7 +59,7 @@ class Util
 		int musicvolume = 75;
 		//A std::string which represents the currently-playing song.
 		String currentMusic;
-		static BorisConsoleManager* BorisConsoleManager;
+		static BorisConsoleManager* borisConsoleManager;
 };
 
 #endif

--- a/BorisEngine2/Vector2.h
+++ b/BorisEngine2/Vector2.h
@@ -2,7 +2,13 @@
 #define _VECTOR2_H
 
 #include "Aliases.h"
-#include "SDL.h"
+
+#ifdef __linux__
+  #include <SDL2/SDL.h>
+#else
+  #include <SDL.h>
+#endif
+
 #include "string"
 
 //A struct which represents an onscreen position using an X and Y value.

--- a/BorisEngine2/cmake-find-modules/FindSDL2.cmake
+++ b/BorisEngine2/cmake-find-modules/FindSDL2.cmake
@@ -1,0 +1,173 @@
+
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDLmain.h and SDLmain.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2DIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2DIR
+# used in building SDL2.
+# l.e.galup  9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+# message("<FindSDL2.cmake>")
+
+SET(SDL2_SEARCH_PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+	${SDL2_PATH}
+)
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES include/SDL2 include
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8) 
+	set(PATH_SUFFIXES lib64 lib/x64 lib)
+else() 
+	set(PATH_SUFFIXES lib/x86 lib)
+endif() 
+
+FIND_LIBRARY(SDL2_LIBRARY_TEMP
+	NAMES SDL2
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES ${PATH_SUFFIXES}
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+IF(NOT SDL2_BUILDING_LIBRARY)
+	IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+		# Non-OS X framework versions expect you to also dynamically link to
+		# SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+		# seem to provide SDL2main for compatibility even though they don't
+		# necessarily need it.
+		FIND_LIBRARY(SDL2MAIN_LIBRARY
+			NAMES SDL2main
+			HINTS
+			$ENV{SDL2DIR}
+			PATH_SUFFIXES ${PATH_SUFFIXES}
+			PATHS ${SDL2_SEARCH_PATHS}
+		)
+	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+	FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional link flag, -mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -mwindows
+IF(MINGW)
+	SET(MINGW32_LIBRARY mingw32 "-mwindows" CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+IF(SDL2_LIBRARY_TEMP)
+	# For SDL2main
+	IF(NOT SDL2_BUILDING_LIBRARY)
+		IF(SDL2MAIN_LIBRARY)
+			SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+		ENDIF(SDL2MAIN_LIBRARY)
+	ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+	# For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+	# CMake doesn't display the -framework Cocoa string in the UI even
+	# though it actually is there if I modify a pre-used variable.
+	# I think it has something to do with the CACHE STRING.
+	# So I use a temporary variable until the end so I can set the
+	# "real" variable in one-shot.
+	IF(APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+	ENDIF(APPLE)
+
+	# For threads, as mentioned Apple doesn't need this.
+	# In fact, there seems to be a problem if I used the Threads package
+	# and try using this line, so I'm just skipping it entirely for OS X.
+	IF(NOT APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+	ENDIF(NOT APPLE)
+
+	# For MinGW library
+	IF(MINGW)
+		SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+	ENDIF(MINGW)
+
+	# Set the final string here so the GUI reflects the final state.
+	SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+	SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+ENDIF(SDL2_LIBRARY_TEMP)
+
+# message("</FindSDL2.cmake>")
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)

--- a/BorisEngine2/cmake-find-modules/FindSDL2_image.cmake
+++ b/BorisEngine2/cmake-find-modules/FindSDL2_image.cmake
@@ -1,0 +1,100 @@
+# Locate SDL_image library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_IMAGE_LIBRARIES, the name of the library to link against
+#   SDL2_IMAGE_INCLUDE_DIRS, where to find the headers
+#   SDL2_IMAGE_FOUND, if false, do not try to link against
+#   SDL2_IMAGE_VERSION_STRING - human-readable string containing the version of SDL_image
+#
+#
+#
+# For backward compatibility the following variables are also set:
+#
+# ::
+#
+#   SDLIMAGE_LIBRARY (same value as SDL2_IMAGE_LIBRARIES)
+#   SDLIMAGE_INCLUDE_DIR (same value as SDL2_IMAGE_INCLUDE_DIRS)
+#   SDLIMAGE_FOUND (same value as SDL2_IMAGE_FOUND)
+#
+#
+#
+# $SDLDIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDLDIR used in building SDL.
+#
+# Created by Eric Wing.  This was influenced by the FindSDL.cmake
+# module, but with modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+        HINTS
+        ENV SDL2IMAGEDIR
+        ENV SDL2DIR
+        PATH_SUFFIXES SDL2
+        # path suffixes to search inside ENV{SDLDIR}
+        include/SDL2 include
+        PATHS ${SDL2_IMAGE_PATH}
+        )
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+    set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+find_library(SDL2_IMAGE_LIBRARY
+        NAMES SDL2_image
+        HINTS
+        ENV SDL2IMAGEDIR
+        ENV SDL2DIR
+        PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+        PATHS ${SDL2_IMAGE_PATH}
+        )
+
+if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MAJOR "${SDL2_IMAGE_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MINOR "${SDL2_IMAGE_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_PATCH "${SDL2_IMAGE_VERSION_PATCH_LINE}")
+    set(SDL2_IMAGE_VERSION_STRING ${SDL2_IMAGE_VERSION_MAJOR}.${SDL2_IMAGE_VERSION_MINOR}.${SDL2_IMAGE_VERSION_PATCH})
+    unset(SDL2_IMAGE_VERSION_MAJOR_LINE)
+    unset(SDL2_IMAGE_VERSION_MINOR_LINE)
+    unset(SDL2_IMAGE_VERSION_PATCH_LINE)
+    unset(SDL2_IMAGE_VERSION_MAJOR)
+    unset(SDL2_IMAGE_VERSION_MINOR)
+    unset(SDL2_IMAGE_VERSION_PATCH)
+endif()
+
+set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})
+set(SDL2_IMAGE_INCLUDE_DIRS ${SDL2_IMAGE_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_image
+        REQUIRED_VARS SDL2_IMAGE_LIBRARIES SDL2_IMAGE_INCLUDE_DIRS
+        VERSION_VAR SDL2_IMAGE_VERSION_STRING)
+
+# for backward compatibility
+set(SDLIMAGE_LIBRARY ${SDL2_IMAGE_LIBRARIES})
+set(SDLIMAGE_INCLUDE_DIR ${SDL2_IMAGE_INCLUDE_DIRS})
+set(SDLIMAGE_FOUND ${SDL2_IMAGE_FOUND})
+
+mark_as_advanced(SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)

--- a/BorisEngine2/cmake-find-modules/FindSDL2_mixer.cmake
+++ b/BorisEngine2/cmake-find-modules/FindSDL2_mixer.cmake
@@ -1,0 +1,100 @@
+# Locate SDL_MIXER library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_MIXER_LIBRARIES, the name of the library to link against
+#   SDL2_MIXER_INCLUDE_DIRS, where to find the headers
+#   SDL2_MIXER_FOUND, if false, do not try to link against
+#   SDL2_MIXER_VERSION_STRING - human-readable string containing the version of SDL_MIXER
+#
+#
+#
+# For backward compatibility the following variables are also set:
+#
+# ::
+#
+#   SDLMIXER_LIBRARY (same value as SDL2_MIXER_LIBRARIES)
+#   SDLMIXER_INCLUDE_DIR (same value as SDL2_MIXER_INCLUDE_DIRS)
+#   SDLMIXER_FOUND (same value as SDL2_MIXER_FOUND)
+#
+#
+#
+# $SDLDIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDLDIR used in building SDL.
+#
+# Created by Eric Wing.  This was influenced by the FindSDL.cmake
+# module, but with modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
+        HINTS
+        ENV SDL2MIXERDIR
+        ENV SDL2DIR
+        PATH_SUFFIXES SDL2
+        # path suffixes to search inside ENV{SDLDIR}
+        include/SDL2 include
+        PATHS ${SDL2_MIXER_PATH}
+        )
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+    set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+find_library(SDL2_MIXER_LIBRARY
+        NAMES SDL2_mixer
+        HINTS
+        ENV SDL2MIXERDIR
+        ENV SDL2DIR
+        PATH_SUFFIXES lib bin ${VC_LIB_PATH_SUFFIX}
+        PATHS ${SDL2_MIXER_PATH}
+        )
+
+if(SDL2_MIXER_INCLUDE_DIR AND EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")
+    file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_MAJOR "${SDL2_MIXER_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_MINOR "${SDL2_MIXER_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_PATCH "${SDL2_MIXER_VERSION_PATCH_LINE}")
+    set(SDL2_MIXER_VERSION_STRING ${SDL2_MIXER_VERSION_MAJOR}.${SDL2_MIXER_VERSION_MINOR}.${SDL2_MIXER_VERSION_PATCH})
+    unset(SDL2_MIXER_VERSION_MAJOR_LINE)
+    unset(SDL2_MIXER_VERSION_MINOR_LINE)
+    unset(SDL2_MIXER_VERSION_PATCH_LINE)
+    unset(SDL2_MIXER_VERSION_MAJOR)
+    unset(SDL2_MIXER_VERSION_MINOR)
+    unset(SDL2_MIXER_VERSION_PATCH)
+endif()
+
+set(SDL2_MIXER_LIBRARIES ${SDL2_MIXER_LIBRARY})
+set(SDL2_MIXER_INCLUDE_DIRS ${SDL2_MIXER_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_mixer
+        REQUIRED_VARS SDL2_MIXER_LIBRARIES SDL2_MIXER_INCLUDE_DIRS
+        VERSION_VAR SDL2_MIXER_VERSION_STRING)
+
+# for backward compatibility
+set(SDLMIXER_LIBRARY ${SDL2_MIXER_LIBRARIES})
+set(SDLMIXER_INCLUDE_DIR ${SDL2_MIXER_INCLUDE_DIRS})
+set(SDLMIXER_FOUND ${SDL2_MIXER_FOUND})
+
+mark_as_advanced(SDL2_MIXER_LIBRARY SDL2_MIXER_INCLUDE_DIR)

--- a/BorisEngine2/cmake-find-modules/FindSDL2_ttf.cmake
+++ b/BorisEngine2/cmake-find-modules/FindSDL2_ttf.cmake
@@ -1,0 +1,98 @@
+# Locate SDL_ttf library
+#
+# This module defines:
+#
+# ::
+#
+#   SDL2_TTF_LIBRARIES, the name of the library to link against
+#   SDL2_TTF_INCLUDE_DIRS, where to find the headers
+#   SDL2_TTF_FOUND, if false, do not try to link against
+#   SDL2_TTF_VERSION_STRING - human-readable string containing the version of SDL_ttf
+#
+#
+#
+# For backward compatibility the following variables are also set:
+#
+# ::
+#
+#   SDLTTF_LIBRARY (same value as SDL2_TTF_LIBRARIES)
+#   SDLTTF_INCLUDE_DIR (same value as SDL2_TTF_INCLUDE_DIRS)
+#   SDLTTF_FOUND (same value as SDL2_TTF_FOUND)
+#
+#
+#
+# $SDLDIR is an environment variable that would correspond to the
+# ./configure --prefix=$SDLDIR used in building SDL.
+#
+# Created by Eric Wing.  This was influenced by the FindSDL.cmake
+# module, but with modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+
+#=============================================================================
+# Copyright 2005-2009 Kitware, Inc.
+# Copyright 2012 Benjamin Eikel
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_path(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
+        HINTS
+        ENV SDL2TTFDIR
+        ENV SDL2DIR
+        PATH_SUFFIXES SDL2
+        # path suffixes to search inside ENV{SDLDIR}
+        include/SDL2 include
+        PATHS ${SDL2_TTF_PATH}
+        )
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(VC_LIB_PATH_SUFFIX lib/x64)
+else ()
+    set(VC_LIB_PATH_SUFFIX lib/x86)
+endif ()
+
+find_library(SDL2_TTF_LIBRARY
+        NAMES SDL2_ttf
+        HINTS
+        ENV SDL2TTFDIR
+        ENV SDL2DIR
+        PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+        PATHS ${SDL2_TTF_PATH}
+        )
+
+if (SDL2_TTF_INCLUDE_DIR AND EXISTS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+[0-9]+$")
+    file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MAJOR "${SDL2_TTF_VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MINOR "${SDL2_TTF_VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_PATCH "${SDL2_TTF_VERSION_PATCH_LINE}")
+    set(SDL2_TTF_VERSION_STRING ${SDL2_TTF_VERSION_MAJOR}.${SDL2_TTF_VERSION_MINOR}.${SDL2_TTF_VERSION_PATCH})
+    unset(SDL2_TTF_VERSION_MAJOR_LINE)
+    unset(SDL2_TTF_VERSION_MINOR_LINE)
+    unset(SDL2_TTF_VERSION_PATCH_LINE)
+    unset(SDL2_TTF_VERSION_MAJOR)
+    unset(SDL2_TTF_VERSION_MINOR)
+    unset(SDL2_TTF_VERSION_PATCH)
+endif ()
+
+set(SDL2_TTF_LIBRARIES ${SDL2_TTF_LIBRARY})
+set(SDL2_TTF_INCLUDE_DIRS ${SDL2_TTF_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_ttf
+        REQUIRED_VARS SDL2_TTF_LIBRARIES SDL2_TTF_INCLUDE_DIRS
+        VERSION_VAR SDL2_TTF_VERSION_STRING)
+
+# for backward compatibility
+set(SDLTTF_LIBRARY ${SDL2_TTF_LIBRARIES})
+set(SDLTTF_INCLUDE_DIR ${SDL2_TTF_INCLUDE_DIRS})
+set(SDLTTF_FOUND ${SDL2_TTF_FOUND})


### PR DESCRIPTION
This will make necessary adjustments, especially to the data type declarations
in header files, in order to allow compilation using GCC 8.3.0. See #2.

Major updates are as follows:

(1) replace instances of LPCSTR with a simple, cross-platform `const char *`.
This enables compilation at the price of additional compiler warnings.

(2) ensure that the static BorisConsoleManager object is renamed to avoid a name
conflict. This will resolve "error: changes meaning of ‘BorisConsoleManager’
from ‘class BorisConsoleManager’".

(3) update `Sprite.cpp` to avoid taking the address of a temporary (on that note,
how did this code ever compile under a modern C++ standard?).

Future work:

Finish updating `BorisOperations.cpp`, which appears to invoke other
Windows-specific functions (`_strdup`, `CreateDirectory`, etc.); address the
write-strings compiler warnings; and of course, make sure that the library is
ultimately linkable.

@Rariolu Nim, remind me: what C++ standard are we using?